### PR TITLE
Resolve network deadlock

### DIFF
--- a/draft-mazieres-dinrg-scp-06.md
+++ b/draft-mazieres-dinrg-scp-06.md
@@ -660,9 +660,13 @@ messages as follows.
   `value` is updated when and only when `counter` changes.
 
 `ballot.counter`
-:  The counter is set according to the following rules:
+: The counter is set according to the following rules, in all cases if
+  setting the counter would not result in setting a value for
+  `ballot.value`, then setting the counter must be delayed until
+  setting the counter would result in setting a value for
+  `ballot.value`:
 
-    * Upon entering the PREPARE phase, the `counter` field is
+    * After entering the PREPARE phase, the `counter` field is
       initialized to 1.
 
     * When a node sees messages from a quorum to which it belongs such


### PR DESCRIPTION
Prior to this change nodes were able to set their "ballot.counter"
without also setting their "ballot.value". Nodes are also forbidden from
sending their prepare message until they have set "ballot.value".

This posed a problem, since a node entering the prepare phase with no
composite value from nomination and no ballot messages from other nodes
would set their "ballot.counter" to 1 but not their "ballot.value" and
therefore would not be able to send their ballot message to the network.

At this point, the only way this node can change their "ballot.counter",
and subsequently send their prepare message to the network is to see a
blocking threshold of nodes with "ballot.counter" greater than theirs or
a quorum of other nodes with "ballot.counter" greater than or equal to
theirs.  Notably even if this node were to confirm nominated a value, it
would not be able to update its prepare message and send it to the
network.

If a sufficient number of other nodes are also not able to send their
prepare message, then it can happen that no nodes in the network are now
able to see a blocking or quorum threshold of messages from other nodes
and the network will get stuck with no nodes able to progress.

This change modifies the conditions for setting "ballot.counter" so that
a node may not set its "ballot.counter" unless it can also set its
"ballot.value". This ensures that as soon as a value is confirmed
nominated, a node will be able to start sending its prepare message.

The way that I have explained this in the spec is not ideal, since the
description of setting the `ballot.counter` now relies on the description of
setting `ballot.value` which is defined later in the document. But without
introducing the concept of a 'next ballot value' which would be a significant
change, I can't see a neater way to explain this.