### PR TITLE
Prevent messages conveying conflicting statements

### DIFF
--- a/draft-mazieres-dinrg-scp-06.md
+++ b/draft-mazieres-dinrg-scp-06.md
@@ -805,7 +805,7 @@ representable in serialized form):
 * `vote-or-accept prepare(<infinity, ballot.value>)`
 * `accept prepare(<preparedCounter, ballot.value>)`
 * `confirm prepare(<hCounter, ballot.value>)`
-* `vote commit(<n, ballot.value>)` for every `n >= cCounter`
+* `vote commit(<n, ballot.value>)` for every `n >= hCounter`
 
 A node computes the fields in the `SCPCommit` messages it sends as
 follows:


### PR DESCRIPTION
It can happen that a node that is in the PREPARE phase with b=(1,a)
moves to the COMMIT phase by accepting comitted c=h=(2,b) and
subsequently accepts comitted (1,b) so c=(1,b) h=(2,b)

If the value b orders before a then during this sequence of operations
the node will have conveyed a vote to abort (1,b) and a vote to commit
(1,b).

I think the solution to this is to modify the statements conveyed by the
SCPCommit message so that only ballots greater than or equal to h are
voted for.